### PR TITLE
Feature/update in place

### DIFF
--- a/src/main/kotlin/io/github/paulgriffith/modification/Entrypoint.kt
+++ b/src/main/kotlin/io/github/paulgriffith/modification/Entrypoint.kt
@@ -56,7 +56,7 @@ class ModificationUpdater : CliktCommand(
         "-a",
         "--actor",
         help = "The new actor name"
-    ).default("external")
+    ).default(System.getProperty("user.name"))
 
     private val timestamp by option(
         "-t",

--- a/src/main/kotlin/io/github/paulgriffith/modification/utils.kt
+++ b/src/main/kotlin/io/github/paulgriffith/modification/utils.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import java.io.InputStream
 import java.time.Instant
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 
@@ -50,15 +51,28 @@ object ApplicationScopeDeserializer : KSerializer<Int> {
     }
 }
 
+fun getDateTimeFormatter() : DateTimeFormatter{
+    return DateTimeFormatter
+        .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        .withLocale(Locale.UK)
+        .withZone(ZoneId.of("UTC"))
+}
+
 object InstantSerializer : KSerializer<Instant> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("java.time.Instant", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+        "java.time.Instant",
+        PrimitiveKind.STRING
+    )
 
     override fun deserialize(decoder: Decoder): Instant {
-        return Instant.parse(decoder.decodeString())
+        val dtf = getDateTimeFormatter()
+
+        return Instant.from(dtf.parse(decoder.decodeString()))
     }
 
     override fun serialize(encoder: Encoder, value: Instant) {
-        encoder.encodeString(DateTimeFormatter.ISO_INSTANT.format(value))
+        val dtf = getDateTimeFormatter()
+        encoder.encodeString(dtf.format(value))
     }
 }
 


### PR DESCRIPTION
## Behavior changed
The default behavior has been changed to update the resource.json file in-place provided that the referenced files have changed.

The default actor is now the system property user.name

## New Flags
Consequentially, there are a couple extra flags
--no-replace / -nr, this will NOT replace the file in-place
--console / -c, this will print the updated resource.json file to the console,
--force, this is a hidden option mostly used to maintain compatibility with existing tests

## Modified Flags
--timestamp / -t has been modified to hidden, as IMHO, the timestamp should only change when the signature is created

## Sundries
Dependency versions were bumped and some explicit versions were added to mitigate a conflict